### PR TITLE
a new file in tests/testthat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: rhdf5client
 Title: Access HDF5 content from h5serv 
 Description: Provides functionality for reading data from h5serv server
  from within R.
-Version: 1.3.10
+Version: 1.3.11
 Authors@R: c(
  person("Samuela", "Pollack", role = c("cre", "aut"),email = "spollack@jimmy.harvard.edu"), 
  person("Shweta", "Gopaulakrishnan", role = c("aut"), email = "reshg@channing.harvard.edu"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: rhdf5client
 Title: Access HDF5 content from h5serv 
 Description: Provides functionality for reading data from h5serv server
  from within R.
-Version: 1.3.11
+Version: 1.3.12
 Authors@R: c(
  person("Samuela", "Pollack", role = c("cre", "aut"),email = "spollack@jimmy.harvard.edu"), 
  person("Shweta", "Gopaulakrishnan", role = c("aut"), email = "reshg@channing.harvard.edu"),

--- a/R/HSDS_Matrix.R
+++ b/R/HSDS_Matrix.R
@@ -1,6 +1,24 @@
 #' simplify construction of DelayedMatrix from url and path in HSDS
 #' @param url character(1) URL for HSDS object store with port
 #' @param path character(1) path from root defining HDF Cloud resource
+#' @return instance of DelayedArray
+#' @examples
+#' HSDS_Matrix
+#' @export
+HSDS_Matrix_OLD = function(url, path) {
+  so = H5S_source(url, path)
+  dss = fetchDatasets(so) 
+  uu = dss$id
+  if (length(uu)>1) message("multiple UUIDs found, using first")
+  uu = uu[1]
+  ds = H5S_dataset2(so, uu)
+  DelayedArray(new("H5S_ArraySeed", filepath="", domain="",
+   host="", H5S_dataset=ds))
+}
+
+#' simplify construction of DelayedMatrix from url and path in HSDS
+#' @param url character(1) URL for HSDS object store with port
+#' @param path character(1) path from root defining HDF Cloud resource
 #' @param title character(1) name of dataset to use
 #' @return instance of DelayedArray
 #' @examples
@@ -8,7 +26,7 @@
 #' @export
 HSDS_Matrix = function(url, path, title) {
   so = H5S_source(url, path)
-  dss = fetchDatasets(so) 
+  dss = fetchDatasets(so)
   uu = dss$id
   if (length(uu)>1) {
     message("multiple UUIDs found")
@@ -23,6 +41,13 @@ HSDS_Matrix = function(url, path, title) {
       }
     }
   ds = H5S_dataset2(so, uu)
+  if (length(ds@shapes$dims)==1) {
+       targ = gsub("&.*", "", ds@presel)
+       gg = fromJSON(readBin(GET(targ)$content,w="character"))$value
+       message("one dimensional response, returning text")
+       return(gg)
+       }
   DelayedArray(new("H5S_ArraySeed", filepath="", domain="",
    host="", H5S_dataset=ds))
 }
+

--- a/R/HSDS_Matrix.R
+++ b/R/HSDS_Matrix.R
@@ -1,18 +1,28 @@
 #' simplify construction of DelayedMatrix from url and path in HSDS
 #' @param url character(1) URL for HSDS object store with port
 #' @param path character(1) path from root defining HDF Cloud resource
+#' @param title character(1) name of dataset to use
 #' @return instance of DelayedArray
 #' @examples
-#' HSDS_Matrix
+#' HSDS_Matrix(URL_hsds(), "/shared/bioconductor/darmgcls.h5")
 #' @export
-HSDS_Matrix = function(url, path) {
+HSDS_Matrix = function(url, path, title) {
   so = H5S_source(url, path)
   dss = fetchDatasets(so) 
   uu = dss$id
-  if (length(uu)>1) message("multiple UUIDs found, using first")
-  uu = uu[1]
+  if (length(uu)>1) {
+    message("multiple UUIDs found")
+    if (missing(title)) {
+      message("no title provided, using first UUID")
+      uu = uu[1]
+      }
+    else {
+      ind = which(dss$title == title)
+      if (length(ind)==1) uu = uu[ind]
+        else stop("title does not pick out a single dataset to use")
+      }
+    }
   ds = H5S_dataset2(so, uu)
   DelayedArray(new("H5S_ArraySeed", filepath="", domain="",
    host="", H5S_dataset=ds))
 }
-

--- a/man/HSDS_Matrix.Rd
+++ b/man/HSDS_Matrix.Rd
@@ -4,12 +4,14 @@
 \alias{HSDS_Matrix}
 \title{simplify construction of DelayedMatrix from url and path in HSDS}
 \usage{
-HSDS_Matrix(url, path)
+HSDS_Matrix(url, path, title)
 }
 \arguments{
 \item{url}{character(1) URL for HSDS object store with port}
 
 \item{path}{character(1) path from root defining HDF Cloud resource}
+
+\item{title}{character(1) name of dataset to use}
 }
 \value{
 instance of DelayedArray
@@ -18,5 +20,5 @@ instance of DelayedArray
 simplify construction of DelayedMatrix from url and path in HSDS
 }
 \examples{
-HSDS_Matrix
+HSDS_Matrix(URL_hsds(), "/shared/bioconductor/darmgcls.h5")
 }

--- a/tests/testthat/getDSrefs.R
+++ b/tests/testthat/getDSrefs.R
@@ -1,0 +1,106 @@
+# 30 August 2018 -- purpose of this code is
+# to verify that key subsetting code related to
+# H5S_dataset2 does not regress
+#
+getDSrefs = function(url = rhdf5client::URL_hsds(), 
+   dompath = "/shared/bioconductor/htxcomp_genes.h5") {
+ ini = httr::GET(paste0(url, "/datasets?domain=", dompath))
+ val = try(rjson::fromJSON(readBin(ini$content, "text")))
+ if (inherits(val, "try-error")) {
+   print(val)
+   stop("GET /datasets failed to produce useful content.")
+   }
+ groups = httr::GET(paste0(url, "/groups?domain=", dompath))
+ groups.val = try(rjson::fromJSON(readBin(groups$content, "text")))
+ if (inherits(groups.val, "try-error")) {
+   print(val)
+   stop("GET /groups failed to produce useful content.")
+   }
+ gtab = do.call(rbind.data.frame, c(groups.val$hrefs, stringsAsFactors=FALSE))
+ rownames(gtab) = gtab$rel
+ prelink = gtab["root","href"]
+ lurl = sub("\\?", "/links?", prelink)
+ links = httr::GET(lurl)
+ links.val = try(rjson::fromJSON(readBin(links$content, "text")))
+ if (inherits(links.val, "try-error")) {
+   print(val)
+   stop("GET /groups/.../links failed to produce useful content.")
+   }
+ ltab = do.call(rbind.data.frame, c(links.val$links, stringsAsFactors=FALSE))
+ ltab
+}
+
+retrieveDataset = function(url=rhdf5client::URL_hsds(), dompath =
+  "/shared/bioconductor/darmgcls.h5", title="assay001") {
+#
+# function will attempt to return a DelayedMatrix with
+# contents given by the [title] element of the [dompath]
+# resource, unless the [title] element is one-dimensional,
+# in which case a character vector is returned
+#
+ s1 = getDSrefs(url, dompath=dompath)
+ uu = s1[which(s1$title == title), "id"]
+ so = rhdf5client::H5S_source(url, dompath)
+ suppressMessages({  # encoding message
+ ds = rhdf5client::H5S_dataset2(so, uu)
+ })
+ if (length(ds@shapes$dims) == 1) {
+        targ = gsub("&.*", "", ds@presel)
+        gg = rjson::fromJSON(readBin(GET(targ)$content, w = "character"))$value
+        message("one dimensional response, returning text")
+        return(gg)
+    }
+ DelayedArray::DelayedArray(new("H5S_ArraySeed", filepath = "", domain = "", 
+         host = "", H5S_dataset = ds))
+}
+ 
+context("H5S_dataset2 exercises")
+
+test_that("darmgcls.h5 can be retrieved from kitalab", {
+ url = URL_hsds()
+ dompath = "/shared/bioconductor/darmgcls.h5"
+ title = "assay001"
+ s1 = try(getDSrefs(url = url, dompath = dompath))
+ if (inherits(s1, "try-error")) {
+   print(s1)
+   fail(paste("getDSrefs fails on", dompath))
+ }
+ uu = s1[which(s1$title == title), "id"]
+ expect_true(length(uu)==1)
+ so = rhdf5client::H5S_source(url, dompath)
+ suppressMessages({  # encoding message
+ ds = rhdf5client::H5S_dataset2(so, uu)
+ })
+ expect_true(is(ds, "H5S_dataset"))
+ ans = DelayedArray::DelayedArray(new("H5S_ArraySeed", 
+         filepath = "", domain = "", 
+         host = "", H5S_dataset = ds))
+ expect_true(all(dim(ans) == c(65218, 3584)))
+
+# compute indices of corners of matrix
+
+corn = function(m, siz=3) {
+ r = nrow(m)
+ c = ncol(m)
+ rr = unlist(lapply(list(head,tail), function(f) f(1:r, siz)))
+ cc = unlist(lapply(list(head,tail), function(f) f(1:c, siz)))
+ list(rr, cc)
+}
+
+mcorn = function(m, siz=4) { 
+  cc = corn(m, siz=siz)
+  m[cc[[1]], cc[[2]]]
+}
+
+expect_equal(sum(mcorn(ans)), 55928.6253033)
+})
+
+context("use retrieveDataset to get rownames")
+
+test_that("retrieveDataset gets rownames", {
+   rn = retrieveDataset(url=rhdf5client::URL_hsds(), dompath =
+       "/shared/bioconductor/htxcomp_genes.h5", title="rownames") 
+   expect_equal(length(rn), 58288)
+   expect_true(all.equal(head(rn), c("ENSG00000000003.14", "ENSG00000000005.5", 	"ENSG00000000419.12", "ENSG00000000457.13", 
+        "ENSG00000000460.16", "ENSG00000000938.12")))
+})


### PR DESCRIPTION
I have added tests/testthat/getDSrefs.R to exercise some functionality
to retrieve matrix data references as DelayedArray matrices and to
retrieve a character vector without delayed protocol.

These tests should pass continuously as the new object design is
deployed.  The key infrastructure elements employed are H5S_dataset2 and
bracket on H5S_dataset instances.  As those are abandoned/replaced
I may need to modify the tests, so let me know when such occurs.